### PR TITLE
Corrected file name and imports for sensor_transformation_utils.py

### DIFF
--- a/opencood/utils/sensor_transformation_utils.py
+++ b/opencood/utils/sensor_transformation_utils.py
@@ -9,7 +9,7 @@ import bisect
 import numpy as np
 from matplotlib import cm
 
-from opencood.utils.opencda_carla import Transform
+# from opencood.utils.opencda_carla import Transform
 
 VIRIDIS = np.array(cm.get_cmap('viridis').colors)
 VID_RANGE = np.linspace(0.0, 1.0, VIRIDIS.shape[0])


### PR DESCRIPTION
The file was erroneously called sensor_transformation_utils.py.py (with the .py extension repeated), so I fixed it to have only one ".py".

Also, the script attempts to import the Transform module from opencood.utils.opencda_carla, which does not exist in this repository. Note that this script actually defines its own Transform class later on, so the import statement on Line 12 seems unnecessary, and breaks the script.